### PR TITLE
Logging fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dbkreduxapi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbkreduxapi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "API to retrieve articles and other content from the DBK site.",
   "apidoc": {
     "name": "The Diamondback API",

--- a/src/utilities/logger.js
+++ b/src/utilities/logger.js
@@ -9,6 +9,7 @@ if (!fs.existsSync('./logs')) {
 const timestamp = new Date(Date.now())
   .toISOString()
   .replace(/:/g, '-');
+const loggerNames = new Set();
 
 /**
  * Serializes an Express request object to a simple object
@@ -35,14 +36,22 @@ function reqSerializer(req) {
 /**
  * Creates an logger with a serializer for Express Request objects. By default,
  * the level is set to `error` and the logger outputs to
- * `./log/{timestamp}-{name}.log`. The value of `timestamp` will be a full ISO
+ * `./log/{timestamp}.log`. The value of `timestamp` will be a full ISO
  * time string, fixed to whenever this module is loaded in.
+ *
+ * Duplicate logger names are not allowed.
  *
  * @param {string} name Name of the logger
  * @param {Logger.LogLevel} level Logging level (see bunyan logger level values
  * for accepted values)
  */
 function createLogger(name, level) {
+  if (loggerNames.has(name)) {
+    throw new Error('Duplicate logger name');
+  }
+
+  loggerNames.add(name);
+
   return bunyan.createLogger({
     name,
     level: level || 'error',
@@ -51,7 +60,7 @@ function createLogger(name, level) {
     },
     streams: [{
       type: 'file',
-      path: `./logs/${timestamp}-${name}.log`
+      path: `./logs/${timestamp}.log`
     }]
   });
 }

--- a/src/utilities/wordpress-service.js
+++ b/src/utilities/wordpress-service.js
@@ -1,6 +1,7 @@
 const fetch = require('node-fetch');
 const url = require('url');
 const { createLogger } = require('./logger');
+require('dotenv').config();
 
 const wpUrlSecure = 'https://wp.dbknews.com';
 const wpUrlOld = "https://wordpress.dbknews.com";
@@ -14,7 +15,7 @@ const categoriesUrl = `${wpUrlSecure}/wp-json/wp/v2/categories`;
 const usersUrl = `${wpUrlSecure}/wp-json/wp/v2/users`;
 const pagesUrl = `${wpUrlSecure}/wp-json/wp/v2/pages`;
 
-const logger = createLogger('dbk-wpapi');
+const logger = createLogger('dbk-wpapi', process.env.LOG_LEVEL);
 
 /** FUNCTIONS USED BY APP.JS **/
 
@@ -417,7 +418,7 @@ function sanitizeUrl(link) {
     if (link.indexOf(target) >= 0) {
       link = link.replace(target, '');
 
-      logger.debug(`sanitizeUrl Replaced ${target}`);
+      logger.info(`sanitizeUrl Replaced ${target}`);
     }
   });
 


### PR DESCRIPTION
- Wordpress API service uses env var `LOG_LEVEL` for creating logger
- All loggers output to a single file
- Each logger should have a distinct name